### PR TITLE
feat: add configurable ITQ initialization for LittleBitLinear (LittleBit-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Banseok Lee*, Dongkyu Kim*, Youngcheon You, Youngmin Kim<br>
 
 **LittleBit** compresses large language models into the sub-1-bit regime by factorizing each dense weight matrix into low-rank latent factors, binarizing those factors, and restoring magnitude information through lightweight learned scales. This enables extreme compression, including the 0.1 bits-per-weight setting, while preserving the original model architecture at inference time.
 
-**LittleBit-2** improves this recipe by addressing latent geometry misalignment in the initialization stage. It applies Internal Latent Rotation with Joint Iterative Quantization (Joint-ITQ), aligning the SVD-derived latent factors with the binary hypercube before QAT. The implementation in this repository now applies LittleBit-2 initialization by default for `LittleBitLinear`, with no additional inference overhead.
+**LittleBit-2** improves this recipe by addressing latent geometry misalignment in the initialization stage. It applies Internal Latent Rotation with Joint Iterative Quantization (Joint-ITQ), aligning the SVD-derived latent factors with the binary hypercube before QAT. LittleBit-2 initialization is available as an opt-in (`--use_itq`) and produces no additional inference overhead.
 
 ---
 
 ## Highlights
 
 - **Sub-1-bit compression:** Designed for 1.0 to 0.1 bits per weight.
-- **LittleBit-2 by default:** `LittleBitLinear` uses Joint-ITQ initialization automatically.
+- **LittleBit-2 opt-in:** Enable Joint-ITQ initialization with `--use_itq` for improved latent geometry alignment.
 - **No inference-time change:** LittleBit-2 modifies initialization only; the deployed factorized layer remains the same.
 - **QAT-friendly:** Supports Quantization-Aware Training with SmoothSign and optional residual factorization.
 
@@ -83,7 +83,7 @@ pip install "transformers==4.51.*"
 
 ### Training
 
-Train a model with Quantization-Aware Training. LittleBit-2 is the default initialization path when using `--quant_mod LittleBitLinear`.
+Train a model with Quantization-Aware Training. By default, `LittleBitLinear` uses the original SVD-only initialization. To enable LittleBit-2 (Joint-ITQ), pass `--use_itq True`.
 
 **Single GPU**
 
@@ -104,6 +104,9 @@ CUDA_VISIBLE_DEVICES=0 python -m main \
     --kv_factor 1.0 \
     --min_split_dim 8 \
     --l2l_loss_scale 10.0
+
+# Opt-in to LittleBit-2 initialization
+# --use_itq True
 ```
 
 **Multi-GPU with DeepSpeed**

--- a/eval.py
+++ b/eval.py
@@ -144,7 +144,9 @@ def main(args):
         # Extract explicit quantization args provided via CLI
         # Only collect arguments that are NOT None (i.e., user explicitly set them)
         quant_kwargs = {}
-        quant_keys = ["quant_func", "quant_mod", "residual", "split_dim", "eff_bit", "kv_factor"]
+        quant_keys = [
+            "quant_func", "quant_mod", "residual", "split_dim", "eff_bit", "kv_factor", "use_itq", "itq_n_iter"
+        ]
         for key in quant_keys:
             val = getattr(args, key)
             if val is not None:
@@ -214,6 +216,8 @@ if __name__ == "__main__":
     parser.add_argument("--split_dim", type=int, default=None)
     parser.add_argument("--eff_bit", type=float, default=None)
     parser.add_argument("--kv_factor", type=float, default=None)
+    parser.add_argument("--use_itq", type=str2bool, default=None)
+    parser.add_argument("--itq_n_iter", type=int, default=None)
 
     # Evaluation args
     parser.add_argument("--ppl_task", type=str, default="wikitext2")

--- a/main.py
+++ b/main.py
@@ -81,6 +81,9 @@ def get_args():
     parser.add_argument("--kv_factor", type=float, default=1.0)
     parser.add_argument("--min_split_dim", type=int, default=8)
 
+    parser.add_argument("--use_itq", type=str2bool, default=False)
+    parser.add_argument("--itq_n_iter", type=int, default=50)
+
     args = parser.parse_args()
 
     return args
@@ -287,6 +290,8 @@ def save_artifacts(trainer, model, tokenizer, save_dir, args):
                 "kv_factor": getattr(args, "kv_factor", 1.0),
                 "min_split_dim": getattr(args, "min_split_dim", 8),
                 "quant_mod": getattr(args, "quant_mod", "LittleBitLinear"),
+                "use_itq": getattr(args, "use_itq", False),
+                "itq_n_iter": getattr(args, "itq_n_iter", 50),
             }
 
             littlebit_config_path = os.path.join(save_dir, "littlebit_config.json")

--- a/quantization/hub.py
+++ b/quantization/hub.py
@@ -41,6 +41,8 @@ class LittleBitConfig:
     residual: bool = False
     kv_factor: float = 1.0
     min_split_dim: int = 8
+    use_itq: bool = False
+    itq_n_iter: int = 50
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -139,6 +141,8 @@ class LittleBitModel(nn.Module, PyTorchModelHubMixin):
         model_config["eff_bit"] = self._littlebit_config.eff_bit
         model_config["split_dim"] = self._littlebit_config.split_dim
         model_config["residual"] = self._littlebit_config.residual
+        model_config["use_itq"] = self._littlebit_config.use_itq
+        model_config["itq_n_iter"] = self._littlebit_config.itq_n_iter
 
         config_path = save_directory / "config.json"
         with open(config_path, "w") as f:
@@ -219,7 +223,10 @@ class LittleBitModel(nn.Module, PyTorchModelHubMixin):
         if model_config_path.exists():
             with open(model_config_path) as f:
                 model_config = json.load(f)
-            for key in ["quant_func", "eff_bit", "split_dim", "residual", "quant_mod", "num_expert", "kv_factor"]:
+            for key in [
+                    "quant_func", "eff_bit", "split_dim", "residual", "quant_mod", "num_expert", "kv_factor", "use_itq",
+                    "itq_n_iter"
+            ]:
                 # Apply fallback if the key exists in model_config and hasn't been explicitly set in config
                 if key in model_config and (not hasattr(config, key)
                                             or getattr(config, key) == getattr(LittleBitConfig(), key)):
@@ -238,6 +245,8 @@ class LittleBitModel(nn.Module, PyTorchModelHubMixin):
             kv_factor=getattr(config, "kv_factor", 1.0),
             min_split_dim=getattr(config, "min_split_dim", 8),
             quant_mod=getattr(config, "quant_mod", "LittleBitLinear"),
+            use_itq=getattr(config, "use_itq", False),
+            itq_n_iter=getattr(config, "itq_n_iter", 50),
             model_id=local_path,
         )
 

--- a/quantization/modules/littlebit.py
+++ b/quantization/modules/littlebit.py
@@ -16,11 +16,15 @@ class LittleBitLinear(nn.Module):
         residual: bool = False,
         ratio_factor: float = 1.0,
         min_split_dim: int = 8,
+        use_itq: bool = False,
+        itq_n_iter: int = 50,
         **kwargs,
     ):
         self.do_train = do_train
         self.quant_func = quant_func
         self.residual = residual
+        self.use_itq = use_itq
+        self.itq_n_iter = itq_n_iter
 
         # Flag to track if weights are binarized to int8 for inference
         self._binarized = False
@@ -286,10 +290,12 @@ class LittleBitLinear(nn.Module):
             V = (sqrt_S.t() @ Vh_t).contiguous()
 
             with torch.no_grad():
-                X_combined = torch.cat([U, V.t()], dim=0)
-                R = self._compute_itq_rotation(X_combined, n_iter=50)
-                U = (U @ R).contiguous()
-                V = (R.t() @ V).contiguous()
+                if self.use_itq:
+                    X_combined = torch.cat([U, V.t()], dim=0)
+                    R = self._compute_itq_rotation(X_combined, n_iter=self.itq_n_iter)
+                    U = (U @ R).contiguous()
+                    V = (R.t() @ V).contiguous()
+                    del X_combined, R
 
             v1, v2 = self._rank_one_decompose(torch.abs(V), calc_device=calc_device)
             u1, u2 = self._rank_one_decompose(torch.abs(U), calc_device=calc_device)
@@ -304,7 +310,7 @@ class LittleBitLinear(nn.Module):
             u2 = u2.to(device=original_device, dtype=dtype)
 
             # Explicitly delete temporary GPU tensors to prevent OOM
-            del X_calc, U_t, S_t, V_t, Vh_t, X_combined, R
+            del X_calc, U_t, S_t, V_t, Vh_t
 
         else:
             U = torch.empty(self.out_features, self.split_dim)

--- a/quantization/utils/quant_util.py
+++ b/quantization/utils/quant_util.py
@@ -131,6 +131,8 @@ def apply_littlebit_patch(model: nn.Module, args, do_train: bool = False):
         "split_dim": getattr(args, "split_dim", 1024),
         "eff_bit": getattr(args, "eff_bit", 1.0),
         "min_split_dim": getattr(args, "min_split_dim", 8),
+        "use_itq": getattr(args, "use_itq", False),
+        "itq_n_iter": getattr(args, "itq_n_iter", 50),
     }
 
     KV_PATTERN = [re.compile(r'\.k_proj$'), re.compile(r'\.v_proj$')]

--- a/quantization/utils/quant_util.py
+++ b/quantization/utils/quant_util.py
@@ -285,6 +285,8 @@ def load_quantized_model(model_path: str, quant_args, torch_dtype, device: str =
         "num_expert": getattr(quant_args, "num_expert", 4),
         "kv_factor": getattr(quant_args, "kv_factor", 1.0),
         "min_split_dim": getattr(quant_args, "min_split_dim", 8),
+        "use_itq": getattr(quant_args, "use_itq", False),
+        "itq_n_iter": getattr(quant_args, "itq_n_iter", 50),
     }
     for key, value in quant_params.items():
         if not hasattr(config, key):


### PR DESCRIPTION
## Summary
This PR extends the LittleBit-2 initialization introduced in #19 by making the Joint-ITQ rotation **configurable** via `use_itq` and `itq_n_iter` parameters. This allows users to choose between the original SVD-only initialization (LittleBit v1) and the latent geometry aligned initialization (LittleBit-2), improving flexibility for reproducibility studies and ablations.

## Changes
- **LittleBitLinear** (`quantization/modules/littlebit.py`): add `use_itq` (default `False`) and `itq_n_iter` (default `50`) parameters. ITQ rotation is now gated.
- **Save/Load pipeline** (`quantization/utils/quant_util.py`, `quantization/hub.py`): propagate `use_itq` and `itq_n_iter` through `littlebit_config.json` serialization and `config.json` fallback.
- **CLI** (`main.py`, `eval.py`): add `--use_itq` and `--itq_n_iter` arguments. Eval forwards overrides to `LittleBitModel.from_pretrained`.
- **Docs** (`README.md`): document the new opt-in flag and clarify that LittleBit-2 is enabled with `--use_itq True`.

## Usage
```bash
# LittleBit-2 training (Joint-ITQ enabled)
python main.py ... --use_itq True

# Original LittleBit training (SVD-only, default)
python main.py ...
```

## Checklist
- [x] yapf formatting applied
- [x] Hub config serialization updated
- [x] CLI args added to both training and evaluation